### PR TITLE
refactor: add date prediction functionality and regex for vencimento

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -64,7 +64,7 @@ RX_TOTAL_LANC_INTER = re.compile(
     re.I
 )
 RX_DATA_VENCIMENTO = re.compile(
-    r"Vencimento:\s(\d{2}/\d{2}/\d{4})",
+    r"(Vencimento|(Com vencimento em)):\s(\d{2}\/\d{2}\/\d{4})",
     re.I
 )
 

--- a/parser.py
+++ b/parser.py
@@ -64,7 +64,7 @@ RX_TOTAL_LANC_INTER = re.compile(
     re.I
 )
 RX_DATA_VENCIMENTO = re.compile(
-    r"(Vencimento|(Com vencimento em)):\s(\d{2}\/\d{2}\/\d{4})",
+    r"(Vencimento|(Com vencimento em)|):?\s(\d{2}\/\d{2}\/\d{4})",
     re.I
 )
 
@@ -203,7 +203,7 @@ def processar_pdf(caminho_pdf: str) -> pd.DataFrame:
             for ln in linhas:
                 has_data_vencimento = RX_DATA_VENCIMENTO.search(ln)
                 if not DATA_VENCIMENTO and has_data_vencimento:
-                    DATA_VENCIMENTO = datetime.strptime(has_data_vencimento.group(1), '%d/%m/%Y').date()
+                    DATA_VENCIMENTO = datetime.strptime(has_data_vencimento.group(3), '%d/%m/%Y').date()
 
                 cartao = detectar_cartao(ln, cartao)
     


### PR DESCRIPTION
This pull request enhances the `parser.py` to improve the handling and prediction of transaction dates in parsed PDF statements. The main change is the introduction of logic to extract and use the statement due date (`DATA_VENCIMENTO`) to infer the correct year for transactions that only include day and month information. This ensures more accurate date assignment for transaction records.

**Date extraction and prediction improvements:**

* Added a new regex pattern `RX_DATA_VENCIMENTO` to detect the statement due date from the PDF text.
* Implemented the `predict_date` function to infer the full transaction date (including year) using the extracted statement due date.
* Modified the main parsing loop in `processar_pdf` to extract `DATA_VENCIMENTO` and use it to predict the year for each transaction date.
* Updated all transaction parsing branches to call `predict_date` before storing transaction data, ensuring all dates have the correct year. [[1]](diffhunk://#diff-df00b01568933a06c611778d2d70679891ebf6e950241d03bb2aa27f3e196fe0R236) [[2]](diffhunk://#diff-df00b01568933a06c611778d2d70679891ebf6e950241d03bb2aa27f3e196fe0R250) [[3]](diffhunk://#diff-df00b01568933a06c611778d2d70679891ebf6e950241d03bb2aa27f3e196fe0R339)

**Imports update:**

* Imported `datetime` from the standard library to support date parsing and manipulation.